### PR TITLE
:arrow_up: Refactor browser launch method in MyLLM class

### DIFF
--- a/myllm/main.py
+++ b/myllm/main.py
@@ -263,7 +263,7 @@ class MyLLM:
         """
         logger.info("Browsing URL: {}", url)
         async with async_playwright() as playwright:
-            browser = await playwright.chromium.launch(headless=False)
+            browser = await playwright.chromium.launch()
             page = await browser.new_page()
             await page.goto(url)
             await asyncio.sleep(2)


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Refactor the browser launch method in the MyLLM class by removing the explicit 'headless=False' parameter, allowing the default headless mode to be used.

Enhancements:
- Remove the explicit 'headless=False' parameter when launching the browser in the 'browse_url' method of the MyLLM class.

<!-- Generated by sourcery-ai[bot]: end summary -->