### PR TITLE
✨ feature: UV build and test

### DIFF
--- a/.github/workflows/👷Flow.yml
+++ b/.github/workflows/👷Flow.yml
@@ -13,11 +13,11 @@ jobs:
     secrets: inherit
   test:
     needs: [lint]
-    uses: mraniki/coding_toolset/.github/workflows/🧪Test.yml@main
+    uses: mraniki/coding_toolset/.github/workflows/UVTest.yml@main
     secrets: inherit
   build:
     needs: [lint]
-    uses: mraniki/coding_toolset/.github/workflows/🐍Build.yml@main
+    uses: mraniki/coding_toolset/.github/workflows/UVBuild.yml@main
     secrets: inherit
   release:
     needs: [build, test]

--- a/.github/workflows/👷Flow.yml
+++ b/.github/workflows/👷Flow.yml
@@ -9,7 +9,9 @@ on:
 
 jobs:
   lint:
-    uses: mraniki/coding_toolset/.github/workflows/🦺Lint.yml@main
+    # Keep linting as is, unless you want to migrate Ruff/etc. management to UV as well
+    # uses: mraniki/coding_toolset/.github/workflows/🦺Lint.yml@main
+    uses: mraniki/coding_toolset/.github/workflows/UVLint.yml@main
     secrets: inherit
   test:
     needs: [lint]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
   "loguru>=0.6.0",
   "httpx>=0.24.1",
   "g4f==0.5.1.6", # Pinned version, keep as is
-  "js2py^0.74",
+  "js2py~=0.74",
   "PyExecJS2==1.6.1", # Pinned version
   "curl_cffi==0.10.0", # Pinned version
   "Brotli==1.1.0", # Pinned version
@@ -43,24 +43,24 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
   "python-semantic-release>=8.0.8",
-  "ruff^0.11.0",
+  "ruff~=0.11",
   # "black^24.0.0", # Kept commented out
-  "pre-commit^4.0.0",
+  "pre-commit~=4.0",
 ]
 test = [
-  "pytest^8.0.0",
-  "pytest-cov^6.0.0",
-  "pytest-asyncio^0.26.0",
-  "pytest-mock^3.11.1",
-  "pytest-loguru^0.4.0",
+  "pytest~=8.0",
+  "pytest-cov~=6.0",
+  "pytest-asyncio~=0.26",
+  "pytest-mock~=3.11",
+  "pytest-loguru~=0.4",
 ]
 docs = [
   "sphinx==7.4.7", # Pinned version
-  "pydata-sphinx-theme^0.14.0",
-  "sphinx-hoverxref^1.3.0",
+  "pydata-sphinx-theme~=0.14",
+  "sphinx-hoverxref~=1.3",
   "sphinx_copybutton==0.5.2", # Pinned version
-  "myst_parser^4.0.0",
-  "sphinx_design^0.6.0",
+  "myst_parser~=4.0",
+  "sphinx_design~=0.6",
   "linkify-it-py==2.0.3", # Pinned version
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,50 +1,74 @@
-[tool.poetry]
+[project]
 name = "MyLLM"
 version = "4.13.57"
 description = "A python package to interact with llm model supported by g4f and langchain."
-authors = ["mraniki <8766259+mraniki@users.noreply.github.com>"]
-license = "MIT License"
+authors = [
+  { name = "mraniki", email = "8766259+mraniki@users.noreply.github.com" },
+]
+license = { text = "MIT License" } # Or use identifier: license = "MIT"
 readme = "README.md"
 keywords = ["chatgpt","llm","ai","llama","ai", "g4f", "freegpt"]
-packages = [
-    {include = "myllm"}
+requires-python = "^3.10" # Copied from tool.poetry.dependencies
+classifiers = [ # Add standard classifiers if desired
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
+dependencies = [
+  "fastapi>=0.95.2",
+  "uvicorn>=0.22.0",
+  "dynaconf>=3.2.0",
+  "loguru>=0.6.0",
+  "httpx>=0.24.1",
+  "g4f==0.5.1.6", # Pinned version, keep as is
+  "js2py^0.74",
+  "PyExecJS2==1.6.1", # Pinned version
+  "curl_cffi==0.10.0", # Pinned version
+  "Brotli==1.1.0", # Pinned version
+  "openai==1.76.0", # Pinned version
+  "groq==0.23.1", # Pinned version
+  # "crawl4ai==0.3.72", # Kept commented out
+  "playwright==1.51.0", # Pinned version
 ]
 
-[tool.poetry.urls]
+[project.urls]
+"Homepage" = "https://github.com/mraniki/MyLLM" # Example, adjust if needed
 "Changelog" =  "https://github.com/mraniki/MyLLM/blob/dev/CHANGELOG.rst"
 "Support" =  "https://github.com/mraniki/MyLLM/discussions"
 "Issues" =  "https://github.com/mraniki/MyLLM/issues"
 
+[project.optional-dependencies]
+dev = [
+  "python-semantic-release>=8.0.8",
+  "ruff^0.11.0",
+  # "black^24.0.0", # Kept commented out
+  "pre-commit^4.0.0",
+]
+test = [
+  "pytest^8.0.0",
+  "pytest-cov^6.0.0",
+  "pytest-asyncio^0.26.0",
+  "pytest-mock^3.11.1",
+  "pytest-loguru^0.4.0",
+]
+docs = [
+  "sphinx==7.4.7", # Pinned version
+  "pydata-sphinx-theme^0.14.0",
+  "sphinx-hoverxref^1.3.0",
+  "sphinx_copybutton==0.5.2", # Pinned version
+  "myst_parser^4.0.0",
+  "sphinx_design^0.6.0",
+  "linkify-it-py==2.0.3", # Pinned version
+]
+
 [build-system]
-requires = ["poetry-core"]
-build-backend = "poetry.core.masonry.api"
+requires = ["setuptools>=61.0"] # Specify a reasonable minimum setuptools version
+build-backend = "setuptools.build_meta"
 
 
-[tool.poetry.dependencies]
-python = "^3.10"
-fastapi = ">=0.95.2"
-uvicorn = ">=0.22.0"
-dynaconf = ">=3.2.0"
-loguru = ">=0.6.0"
-httpx = ">=0.24.1"
-g4f = "0.5.1.6"
-js2py = "^0.74"
-PyExecJS2="1.6.1"
-curl_cffi = "0.10.0"
-Brotli = "1.1.0"
-openai = "1.76.0"
-groq = "0.23.1"
-# crawl4ai = "0.3.72"
-playwright = "1.51.0"
-
-
-
-[tool.poetry.group.dev.dependencies]
-python-semantic-release = ">=8.0.8"
-ruff = "^0.11.0"
-# black = "^24.0.0"
-pre-commit = "^4.0.0"
-
+# Keep existing tool configurations
 [tool.ruff]
 exclude = [
   ".github/*",
@@ -58,7 +82,6 @@ select = [
   "I",  # isort
   "W"
 ]
-
 #ignore = ["E401","F401","F811"]
 fixable = ["ALL"]
 
@@ -66,182 +89,12 @@ fixable = ["ALL"]
 # Like Black, use double quotes for strings.
 quote-style = "double"
 
-
-[tool.pylint.exceptions]
+[tool.pylint.exceptions] # Assuming this is used by pre-commit or linting, keep it
 overgeneral-exceptions = [
     "builtins.BaseException",
     "builtins.Exception",
     "builtins.RuntimeError",
 ]
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-[tool.poetry.group.test.dependencies]
-pytest = "^8.0.0"
-pytest-cov = "^6.0.0"
-pytest-asyncio = "^0.26.0"
-pytest-mock = "^3.11.1"
-pytest-loguru = "^0.4.0"
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-[tool.poetry.group.docs]
-optional = true
-
-[tool.poetry.group.docs.dependencies]
-sphinx = "7.4.7"
-pydata-sphinx-theme = "^0.14.0"
-sphinx-hoverxref = "^1.3.0"
-sphinx_copybutton = "0.5.2"
-myst_parser = "^4.0.0"
-sphinx_design = "^0.6.0"
-linkify-it-py = "2.0.3"
 
 [tool.pytest.ini_options]
 pythonpath = "."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,13 +5,14 @@ description = "A python package to interact with llm model supported by g4f and 
 authors = [
   { name = "mraniki", email = "8766259+mraniki@users.noreply.github.com" },
 ]
-license = { text = "MIT License" } # Or use identifier: license = "MIT"
+# license = { text = "MIT License" } # Or use identifier: license = "MIT"
+license = { file = "LICENSE" } # Point to the license file
 readme = "README.md"
 keywords = ["chatgpt","llm","ai","llama","ai", "g4f", "freegpt"]
 # requires-python = "^3.10" # Copied from tool.poetry.dependencies
 requires-python = ">=3.10" # Use standard PEP 621 specifier
 classifiers = [ # Add standard classifiers if desired
-    "License :: OSI Approved :: MIT License",
+    # "License :: OSI Approved :: MIT License", # Removed, covered by license field
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -68,6 +69,8 @@ docs = [
 requires = ["setuptools>=61.0"] # Specify a reasonable minimum setuptools version
 build-backend = "setuptools.build_meta"
 
+[tool.setuptools]
+packages = ["myllm"]
 
 # Keep existing tool configurations
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,8 @@ authors = [
 license = { text = "MIT License" } # Or use identifier: license = "MIT"
 readme = "README.md"
 keywords = ["chatgpt","llm","ai","llama","ai", "g4f", "freegpt"]
-requires-python = "^3.10" # Copied from tool.poetry.dependencies
+# requires-python = "^3.10" # Copied from tool.poetry.dependencies
+requires-python = ">=3.10" # Use standard PEP 621 specifier
 classifiers = [ # Add standard classifiers if desired
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
@@ -123,10 +124,12 @@ skips = ["B101","B104"]
 [tool.semantic_release]
 upload_to_vcs_release = true
 version_variables = ["myllm/__init__.py:__version__"]
-build_command = "pip install poetry && poetry build"
+# build_command = "pip install poetry && poetry build" # Remove or update for UV/setuptools if needed
+build_command = "uv build --sdist --wheel" # Use uv build command
 commit_parser = "emoji"
 version_toml = [
-   "pyproject.toml:tool.poetry.version",
+   # "pyproject.toml:tool.poetry.version",
+   "pyproject.toml:project.version", # Point to the standard project version
    ]
 
 


### PR DESCRIPTION
## Summary by Sourcery

Migrate project packaging configuration from Poetry to standard Setuptools using PEP 621.

Build:
- Update `pyproject.toml` to use the `[project]` table for metadata and dependencies instead of `[tool.poetry]`.
- Change the build system from `poetry-core` to `setuptools`.