### PR TITLE
👷 CI Change build(deps): update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,9 +136,6 @@ version_toml = [
    ]
 
 
-
-
-
 [tool.semantic_release.commit_parser_options]
 major_tags = [
     "BREAKING",


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Remove trailing whitespace from `pyproject.toml`.