### PR TITLE
👷 CI Change build(deps): update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,6 +142,9 @@ version_toml = [
 
 
 
+
+
+
 [tool.semantic_release.commit_parser_options]
 major_tags = [
     "BREAKING",


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Add empty lines to `pyproject.toml` before the semantic release configuration.