### PR TITLE
📝 chore: update .readthedocs.yaml

### DIFF
--- a/docs/.readthedocs.yaml
+++ b/docs/.readthedocs.yaml
@@ -4,11 +4,10 @@ build:
   os: "ubuntu-22.04"
   tools:
     python: "3.11"
+    uv: "latest"
   jobs:
-    post_create_environment:
-      - python -m pip install poetry
     post_install:
-      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH python -m poetry install --with docs
+      - uv pip install -e '.[docs]'
 
 sphinx:
   configuration: docs/conf.py


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Replace `poetry` with `uv` for installing documentation dependencies in the Read the Docs build job.