### PR TITLE
⬆️ 🤖 - Cold hands no gloves

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
   "PyExecJS2==1.6.1", # Pinned version
   "curl_cffi==0.10.0", # Pinned version
   "Brotli==1.1.0", # Pinned version
-  "openai==1.78.0", # Pinned version
+  "openai==1.78.1", # Pinned version
   "groq==0.24.0", # Pinned version
   # "crawl4ai==0.3.72", # Kept commented out
   "playwright==1.52.0", # Pinned version


### PR DESCRIPTION
Auto Release

## Summary by Sourcery

Build:
- Bump openai dependency from 1.78.0 to 1.78.1